### PR TITLE
Add tsh routines in HYB-LIO

### DIFF
--- a/src/do_energy_forces.f90
+++ b/src/do_energy_forces.f90
@@ -15,7 +15,7 @@
 	Etots, constropt,nconstr, nstepconstr, typeconstr, kforce, ro, &
 	rt, coef, atmsconstr, ndists, istepconstr, rcortemm, &
 	radblommbond, optimization_lvl, dt, sfc, water, imm, rini, rfin, &
-        vel_lio, do_HOPP)
+        vel_lio, do_HOPP, do_ElecInterp)
 
 ! Modules
 	use precision, only: dp
@@ -73,7 +73,8 @@
 ! Lio
 	logical, intent(in) :: do_SCF, do_QM_forces !control for make new calculation of rho, forces in actual step
 	logical, intent(in) :: do_properties !control for lio properties calculation
-	logical, intent(inout) :: do_HOPP ! control for TSH hopp with LIO
+	logical, intent(in) :: do_ElecInterp ! control for TSH routine
+	logical, intent(inout) :: do_HOPP    ! control for TSH hopp with LIO
 
 ! Optimization scheme
 	integer, intent(in) :: optimization_lvl ! level of movement in optimization scheme:
@@ -135,17 +136,9 @@
 
 	  if (leqi(qm_level,'lio')) then ! call Lio QM/MM
 #ifdef LIO
-          if ( do_HOPP ) then
-            ! call LIO to perform electronic interpolation and
-            ! calculates hopp probabilities
-            call TSH_hyb(na_u, at_MM_cut_QMMM, r_cut_QMMM, Etot, &
-            F_cut_QMMM, Iz_cut_QMMM, do_SCF, do_QM_forces, &
-            do_properties, vel_lio, do_HOPP)
-          else
-            call SCF_hyb(na_u, at_MM_cut_QMMM, r_cut_QMMM, Etot, &
-            F_cut_QMMM, Iz_cut_QMMM, do_SCF, do_QM_forces, &
-            do_properties) !fuerzas lio, Nick
-          endif
+         call SCF_hyb(na_u, at_MM_cut_QMMM, r_cut_QMMM, Etot, &
+               F_cut_QMMM, Iz_cut_QMMM, do_SCF, do_QM_forces, &
+               do_properties, vel_lio, do_HOPP, do_ElecInterp) !fuerzas lio, Nick
 #else
 	  stop ('lio not defined compile with qm_lio=1')
 #endif

--- a/src/dynamics.f
+++ b/src/dynamics.f
@@ -1,5 +1,12 @@
       subroutine verlet2(istep,iunit,iquench,natoms,fa,dt,ma,ntcon,va,
-     .                   xa,kin,temp,nfree,cmcf)
+     .                   xa, kin, temp, nfree, cmcf, rcorteqmmm, 
+     .                   radbloqmmm, Etot, do_SCF, do_QM_forces, 
+     .                   do_properties, istp, step, nbond, nangle, 
+     .                   ndihe, nimp, Etot_amber, Elj, Etots, constropt,
+     .                   nconstr, nstepconstr, typeconstr, kforce, ro, 
+     .                   rt, coef, atmsconstr, ndists, istepconstr, 
+     .                   rcortemm, radblommbond, optimization_lvl, sfc, 
+     .                   water, imm, rini, rfin)
 C *************************************************************************
 C Subroutine for MD simulations using the velocity-Verlet Algrithm.
 C (See Allen-Tildesley, Computer Simulations of Liquids, pg. 81)
@@ -47,7 +54,7 @@ C
 C  Modules
 C
       use precision
-      use scarlett, only: Ang,eV
+      use scarlett, only: Ang,eV,na_u,HYB_TSH
       implicit none
 
       integer 
@@ -56,7 +63,36 @@ C
       double precision
      .  dt,fa(3,natoms),kin,ma(natoms),
      .  va(3,natoms),xa(3,natoms)
-
+C Input to forces
+      integer, intent(inout) :: step !total number of steps in a MMxQM movement (not tested in this version)
+      integer, intent(in) :: istp !number of move step for each restrain starting on 1
+      integer, intent(in) :: imm !MM step by QM each step
+      integer, intent(in) :: nbond, nangle, ndihe, nimp !number of bonds, angles, dihedrals and impropers defined in amber.parm
+      real(dp), intent(inout) :: Etot ! QM + QM-MM interaction energy
+      double precision, intent(out) :: Etot_amber !total MM energy
+      double precision, intent(out) :: Elj !LJ interaction (only QMMM)
+      double precision, intent(out) :: Etots !QM+QMMM+MM energy
+      double precision, intent(in) :: rcortemm ! distance for LJ & Coulomb MM interaction
+      double precision, intent(in) :: radblommbond !parche para omitir bonds en extremos terminales
+      double precision :: rcorteqmmm !Distance for QM-MM interaction
+      double precision, intent(in) :: radbloqmmm !Distance that allow to move MM atoms from QM sub-system
+      logical, intent(in) :: do_SCF, do_QM_forces !control for make new calculation of rho, forces in actual step
+      logical, intent(in) :: do_properties !control for lio properties calculation
+      integer, intent(in) :: optimization_lvl ! level of movement in optimization scheme:
+      logical, intent(in) :: constropt !activate restrain optimizaion
+      integer, intent(in) :: nconstr !number of constrains
+      integer, intent(in) :: nstepconstr !numero de pasos en los que barrera la coordenada de reaccion
+      integer, dimension(20), intent(in) :: typeconstr !type of cosntrain (1 to 8)
+      double precision, dimension(20), intent(in) :: kforce !force constant of constrain i
+      double precision :: rini,rfin  !initial and end value of reaction coordinate
+      double precision, dimension(20), intent(in) :: ro ! fixed value of constrain in case nconstr > 1 for contrains 2+
+      double precision, dimension(20), intent(inout) :: rt ! value of reaction coordinate in constrain i
+      double precision, dimension(20,10), intent(in) :: coef ! coeficients for typeconstr=8
+      integer, dimension(20,20), intent(in) :: atmsconstr
+      integer, dimension(20), intent(in) :: ndists !atomos incluidos en la coordenada de reaccion
+      integer, intent(in) :: istepconstr !step of restraint 
+      double precision, intent(in) :: sfc
+      logical, intent(in) :: water
 
 C Internal variables ..........................................................
  
@@ -67,7 +103,9 @@ C Internal variables ..........................................................
      .  dot,dt2,dtby2,fovermp,temp
       
       double precision, dimension(:,:), allocatable, save ::
-     .  accold,vold
+     .  accold,vold,vel_to_lio,fa_to_lio
+
+      logical :: do_HOPP ! TSH hopp
 C ........................
 
 
@@ -139,6 +177,31 @@ C Quench velocity components going uphill
 
       endif
 C ................
+
+C Surface Hopping
+      if ( HYB_TSH ) then
+         do_HOPP = .true.
+         allocate(vel_to_lio(3,na_u)); vel_to_lio = va(:,1:na_u)
+         allocate(fa_to_lio(3,natoms)); fa_to_lio = fa
+         call do_energy_forces(rcorteqmmm, radbloqmmm, Etot,
+     .        do_SCF, do_QM_forces, do_properties, istp, step,
+     .        nbond, nangle, ndihe, nimp, Etot_amber, Elj,
+     .        Etots, constropt,nconstr, nstepconstr, typeconstr, kforce,
+     .        ro, rt, coef, atmsconstr, ndists, istepconstr, rcortemm,
+     .        radblommbond, optimization_lvl, dt, sfc, water,
+     .        1, rini, rfin, vel_to_lio, do_HOPP)
+
+C             If the hopp is frustated -> do_TSH = .false., but if the hopp has occurred
+C             the hopp is .true. -> change forces
+         if ( do_HOPP ) then
+            write(6,*) "HOPP, Changes vel and forces in HYB"
+            va(:,1:na_u) = vel_to_lio
+         else
+            write(6,*) "NO HOPP"
+            fa=fa_to_lio
+         endif
+         deallocate(vel_to_lio,fa_to_lio)
+      endif ! end HYB TSH
 
 C Compute positions at next time step.....................................
       do ia = 1,natoms

--- a/src/dynamics.f
+++ b/src/dynamics.f
@@ -180,7 +180,7 @@ C ................
 
 C Surface Hopping
       if ( HYB_TSH ) then
-         do_HOPP = .true.
+         do_HOPP = .false.
          allocate(vel_to_lio(3,na_u)); vel_to_lio = va(:,1:na_u)
          allocate(fa_to_lio(3,natoms)); fa_to_lio = fa
          call do_energy_forces(rcorteqmmm, radbloqmmm, Etot,
@@ -189,7 +189,7 @@ C Surface Hopping
      .        Etots, constropt,nconstr, nstepconstr, typeconstr, kforce,
      .        ro, rt, coef, atmsconstr, ndists, istepconstr, rcortemm,
      .        radblommbond, optimization_lvl, dt, sfc, water,
-     .        1, rini, rfin, vel_to_lio, do_HOPP)
+     .        1, rini, rfin, vel_to_lio, do_HOPP, .true.)
 
 C             If the hopp is frustated -> do_TSH = .false., but if the hopp has occurred
 C             the hopp is .true. -> change forces

--- a/src/hybrid.f
+++ b/src/hybrid.f
@@ -416,7 +416,7 @@
         Etot=0.d0
         fa=0.d0
 #ifdef LIO
-        call init_lio_hybrid(1,na_u, nac, charge, iza, spin, dt)
+        call init_lio_hybrid(2,na_u, nac, charge, iza, spin, dt)
 #else
 	if (leqi(qm_level,'orca')) then
 	else
@@ -556,7 +556,7 @@ C Calculate Rcut & block list QM-MM
      . Etots, constropt,nconstr, nstepconstr, typeconstr, kforce, ro,
      . rt, coef, atmsconstr, ndists, istepconstr, rcortemm,
      . radblommbond, optimization_lvl, dt, sfc, water,
-     . imm, rini, rfin, vat, .false.)
+     . imm, rini, rfin, vat, .false., .false.)
 
       call wripdb(na_u,slabel,rclas,natot,step,nac,atname,
      .            aaname,aanum,nesp,atsym,isa,listqmmm,blockqmmm)

--- a/src/hybrid.f
+++ b/src/hybrid.f
@@ -416,7 +416,7 @@
         Etot=0.d0
         fa=0.d0
 #ifdef LIO
-        call init_lio_hybrid(1,na_u, nac, charge, iza, spin)
+        call init_lio_hybrid(1,na_u, nac, charge, iza, spin, dt)
 #else
 	if (leqi(qm_level,'orca')) then
 	else
@@ -556,7 +556,7 @@ C Calculate Rcut & block list QM-MM
      . Etots, constropt,nconstr, nstepconstr, typeconstr, kforce, ro,
      . rt, coef, atmsconstr, ndists, istepconstr, rcortemm,
      . radblommbond, optimization_lvl, dt, sfc, water,
-     . imm, rini, rfin)
+     . imm, rini, rfin, vat, .false.)
 
       call wripdb(na_u,slabel,rclas,natot,step,nac,atname,
      .            aaname,aanum,nesp,atsym,isa,listqmmm,blockqmmm)
@@ -647,9 +647,15 @@ C Write atomic forces
 	  call check_convergence(relaxd, natot, cfdummy)
 	  if (.not. relaxd) call FIRE(natot, rclas, cfdummy, vat,
      .    time_steep, Ndescend, time_steep_max, alpha)
-	elseif (idyn .eq. 4) then !verlet
+	elseif (idyn .eq. 4) then !verlet or TSH
 	  call verlet2(istp, 3, 0, natot, cfdummy, dt,
-     .        masst, ntcon, vat, rclas, Ekinion, tempion, nfree, cmcf)
+     .        masst, ntcon, vat, rclas, Ekinion, tempion, nfree, cmcf,
+     .        rcorteqmmm, radbloqmmm, Etot, do_SCF, do_QM_forces, 
+     .        do_properties, istp, step, nbond, nangle, ndihe, nimp, 
+     .        Etot_amber, Elj, Etots, constropt,nconstr, nstepconstr, 
+     .        typeconstr, kforce, ro, rt, coef, atmsconstr, ndists, 
+     .        istepconstr, rcortemm, radblommbond, optimization_lvl,
+     .        sfc, water, imm, rini, rfin)
 !iquench lo dejamos como 0, luego cambiar
         elseif (idyn .eq. 5) then !berendsen
           call berendsen(istp,3,natot,cfdummy,dt,tauber,masst,

--- a/src/readall.f
+++ b/src/readall.f
@@ -128,7 +128,7 @@ C  Modules
      .   NEB_Nimages, time_steep, time_steep_max, traj_frec,
      .   lambda_i, Steep_change, normal_mass, lbfgs_verbose,
      .   lbfgs_num_corr, qm_level, qm_header_lines, qm_header,
-     .   qm_command
+     .   qm_command, HYB_TSH
 
 
       implicit none
@@ -317,6 +317,12 @@ C Read if use saved XV data
           write(6,'(a,4x,l1)')
      .     'read: Use continuation files for XV    = ',
      .     usesavexv
+
+C Read TSH variable
+      HYB_TSH = fdf_boolean('MD.HYB_TSH', .false.)
+          write(6,'(a,4x,l1)')
+     .     'read: Perform TSH dynamics?            = ',
+     .     HYB_TSH
 
 C Maximum number of steps in CG coordinate optimization
       nmove_default = 0

--- a/src/scarlett_mod.f90
+++ b/src/scarlett_mod.f90
@@ -276,4 +276,7 @@
 ! Nuevos jota
 	double precision :: Nav !Avogadro Number
 	double precision :: pi  
+
+! Perform TSH with HYB-LIO
+        logical :: HYB_TSH = .false.
 	end module scarlett


### PR DESCRIPTION
With this PR is possible perform Surface Hopping in Hybrid. This only works when the qm program is LIO. In order to perform Non-Adiabatic Dyamics you have to set HYB_TSH = T in the fdf file and set the corresponding variables in LIO input.