### PR TITLE
Bugfix in XVr

### DIFF
--- a/src/hybrid.f90
+++ b/src/hybrid.f90
@@ -476,6 +476,7 @@ Program HYBRID
       if (nconstr .eq. 1 .and. typeconstr(1) .eq. 9) then
          allocate(vatr(3,natot))
          call ioxv('read',natot,ucell,rref,vatr,foundxvr,foundvatr,'r',-1)
+         if (.not. foundxvr) rref=rclas
 !cambiar ucell cuando haya caja
       endif
 


### PR DESCRIPTION
Bugfix: Ahora si no existe un XVr, toma como coordenadas de referencia las iniciales